### PR TITLE
Set Cache-Control:no-cache for res code 404, 405, and 500.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"html/template"
+	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -12,6 +13,7 @@ import (
 func CreateHandler(config Config) http.Handler {
 	router := httprouter.New()
 	router.RedirectTrailingSlash = false
+	router.NotFound = notFoundHandlerFunc
 
 	router.GET("/", indexHandler{config: config}.Handle)
 
@@ -26,6 +28,14 @@ func CreateHandler(config Config) http.Handler {
 	}
 
 	return router
+}
+
+func notFoundHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	// don't cache 404s so that edge caches always request from origin
+	w.Header().Set("Cache-Control", "no-cache")
+
+	w.WriteHeader(http.StatusNotFound)
+	io.WriteString(w, "404 page not found")
 }
 
 type indexHandler struct {

--- a/handler.go
+++ b/handler.go
@@ -14,6 +14,8 @@ func CreateHandler(config Config) http.Handler {
 	router := httprouter.New()
 	router.RedirectTrailingSlash = false
 	router.NotFound = notFoundHandlerFunc
+	router.HandleMethodNotAllowed = true
+	router.MethodNotAllowed = methodNotAllowedHandlerFunc
 
 	router.GET("/", indexHandler{config: config}.Handle)
 
@@ -28,14 +30,6 @@ func CreateHandler(config Config) http.Handler {
 	}
 
 	return router
-}
-
-func notFoundHandlerFunc(w http.ResponseWriter, r *http.Request) {
-	// don't cache 404s so that edge caches always request from origin
-	w.Header().Set("Cache-Control", "no-cache")
-
-	w.WriteHeader(http.StatusNotFound)
-	io.WriteString(w, "404 page not found")
 }
 
 type indexHandler struct {
@@ -96,3 +90,19 @@ var packageTemplate = template.Must(template.New("package").Parse(`
     </body>
 </html>
 `))
+
+func notFoundHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	// don't cache 404s so that edge caches always request from origin
+	w.Header().Set("Cache-Control", "no-cache")
+
+	w.WriteHeader(http.StatusNotFound)
+	io.WriteString(w, "404 page not found")
+}
+
+func methodNotAllowedHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	// don't cache 405s so that edge caches always request from origin
+	w.Header().Set("Cache-Control", "no-cache")
+
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	io.WriteString(w, "405 method not allowed")
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -18,7 +18,7 @@ packages:
 `
 
 func TestIndex(t *testing.T) {
-	rr := CallAndRecord(t, config, "/")
+	rr := CallAndRecord(t, config, "GET", "/")
 	AssertResponse(t, rr, 200, `
 <!DOCTYPE html>
 <html>
@@ -33,7 +33,7 @@ func TestIndex(t *testing.T) {
 }
 
 func TestPackageShouldExist(t *testing.T) {
-	rr := CallAndRecord(t, config, "/yarpc")
+	rr := CallAndRecord(t, config, "GET", "/yarpc")
 	AssertResponse(t, rr, 200, `
 <!DOCTYPE html>
 <html>
@@ -50,7 +50,7 @@ func TestPackageShouldExist(t *testing.T) {
 }
 
 func TestNonExistentPackageShould404(t *testing.T) {
-	rr := CallAndRecord(t, config, "/nonexistent")
+	rr := CallAndRecord(t, config, "GET", "/nonexistent")
 	AssertResponse(t, rr, 404, `
 404 page not found
 `)
@@ -58,7 +58,7 @@ func TestNonExistentPackageShould404(t *testing.T) {
 }
 
 func TestTrailingSlash(t *testing.T) {
-	rr := CallAndRecord(t, config, "/yarpc/")
+	rr := CallAndRecord(t, config, "GET", "/yarpc/")
 	AssertResponse(t, rr, 200, `
 <!DOCTYPE html>
 <html>
@@ -75,7 +75,7 @@ func TestTrailingSlash(t *testing.T) {
 }
 
 func TestDeepImports(t *testing.T) {
-	rr := CallAndRecord(t, config, "/yarpc/heeheehee")
+	rr := CallAndRecord(t, config, "GET", "/yarpc/heeheehee")
 	AssertResponse(t, rr, 200, `
 <!DOCTYPE html>
 <html>
@@ -90,7 +90,7 @@ func TestDeepImports(t *testing.T) {
 </html>
 `)
 
-	rr = CallAndRecord(t, config, "/yarpc/heehee/hawhaw")
+	rr = CallAndRecord(t, config, "GET", "/yarpc/heehee/hawhaw")
 	AssertResponse(t, rr, 200, `
 <!DOCTYPE html>
 <html>
@@ -104,4 +104,12 @@ func TestDeepImports(t *testing.T) {
     </body>
 </html>
 `)
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	rr := CallAndRecord(t, config, "POST", "/")
+	AssertResponse(t, rr, 405, `
+405 method not allowed
+`)
+	assert.Equal(t, "no-cache", rr.Header().Get("Cache-Control"))
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -120,3 +120,9 @@ func TestMethodNotAllowed(t *testing.T) {
 		}
 	}
 }
+
+func TestInternalServerError(t *testing.T) {
+	rr := CallAndRecord(t, config, "GET", "/panic")
+	AssertResponse(t, rr, 500, "\n500 internal server error\n")
+	assert.Equal(t, "no-cache", rr.Header().Get("Cache-Control"))
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 var config = `
 
@@ -50,6 +54,7 @@ func TestNonExistentPackageShould404(t *testing.T) {
 	AssertResponse(t, rr, 404, `
 404 page not found
 `)
+	assert.Equal(t, "no-cache", rr.Header().Get("Cache-Control"))
 }
 
 func TestTrailingSlash(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,9 +108,15 @@ func TestDeepImports(t *testing.T) {
 }
 
 func TestMethodNotAllowed(t *testing.T) {
-	rr := CallAndRecord(t, config, "POST", "/")
-	AssertResponse(t, rr, 405, `
-405 method not allowed
-`)
-	assert.Equal(t, "no-cache", rr.Header().Get("Cache-Control"))
+	methods := []string{"POST", "PUT", "DELETE", "OPTIONS", "HEAD"}
+	uris := []string{"/", "/yarpc"}
+	for _, method := range methods {
+		for _, uri := range uris {
+			t.Run(fmt.Sprintf("%s => %s", method, uri), func(t *testing.T) {
+				rr := CallAndRecord(t, config, method, uri)
+				AssertResponse(t, rr, 405, "\n405 method not allowed\n")
+				assert.Equal(t, "no-cache", rr.Header().Get("Cache-Control"))
+			})
+		}
+	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -44,11 +44,11 @@ func CreateHandlerFromYAML(t *testing.T, content string) (handler http.Handler, 
 }
 
 // CallAndRecord makes a GET request to the Sally handler and returns a response recorder
-func CallAndRecord(t *testing.T, config string, uri string) *httptest.ResponseRecorder {
+func CallAndRecord(t *testing.T, config string, method string, uri string) *httptest.ResponseRecorder {
 	handler, clean := CreateHandlerFromYAML(t, config)
 	defer clean()
 
-	req, err := http.NewRequest("GET", uri, nil)
+	req, err := http.NewRequest(method, uri, nil)
 	if err != nil {
 		t.Fatalf("Unable to create request to %s: %v", uri, err)
 	}


### PR DESCRIPTION
I'd like to use Cloudflare Page Rules cache to cache all successful requests for a day - that will reduce calls to GAE and more importantly allow us to survive any outage for up to a day.

This PR makes sure that we never store these cache negatives.

cc @prashantv @abhinav @billf 

Resolves #18 
