### PR TITLE
Enforce alphabetical ordering of packages in YAML config

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"sort"
 
@@ -60,7 +60,7 @@ func Parse(path string) (*Config, error) {
 	}
 
 	if !ensureAlphabetical(data) {
-		return nil, errors.New("YAML configuration is not listed alphabetically")
+		return nil, fmt.Errorf("Packages in %s must be alphabetically ordered.", path)
 	}
 
 	return &c, err

--- a/config.go
+++ b/config.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"io/ioutil"
+	"sort"
 
 	"gopkg.in/yaml.v2"
 )
@@ -12,23 +14,54 @@ type Config struct {
 	Packages map[string]Package `yaml:"packages"`
 }
 
+// orderedConfig is used internally to check for alphabetical ordering in the YAML
+// configuration. A yaml.MapSlice perservers ordering of keys: https://godoc.org/gopkg.in/yaml.v2#MapSlice
+type orderedConfig struct {
+	URL      string        `yaml:"url"`
+	Packages yaml.MapSlice `yaml:"packages"`
+}
+
 // Package details the options available for each repo
 type Package struct {
 	Repo string `yaml:"repo"`
 }
 
+// ensureAlphabetical checks that the packages are listed alphabetically in the configuration.
+func ensureAlphabetical(data []byte) bool {
+	var c orderedConfig
+
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return false
+	}
+
+	packageNames := make([]string, len(c.Packages))
+	for _, v := range c.Packages {
+		name, ok := v.Key.(string)
+		if !ok {
+			return false
+		}
+		packageNames = append(packageNames, name)
+	}
+
+	return sort.StringsAreSorted(packageNames)
+}
+
 // Parse takes a path to a yaml file and produces a parsed Config
-func Parse(path string) (Config, error) {
+func Parse(path string) (*Config, error) {
 	var c Config
 
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return c, err
+		return nil, err
 	}
 
 	if err := yaml.Unmarshal(data, &c); err != nil {
-		return c, err
+		return nil, err
 	}
 
-	return c, err
+	if !ensureAlphabetical(data) {
+		return nil, errors.New("YAML configuration is not listed alphabetically")
+	}
+
+	return &c, err
 }

--- a/config.go
+++ b/config.go
@@ -14,13 +14,6 @@ type Config struct {
 	Packages map[string]Package `yaml:"packages"`
 }
 
-// orderedConfig is used internally to check for alphabetical ordering in the YAML
-// configuration. A yaml.MapSlice perservers ordering of keys: https://godoc.org/gopkg.in/yaml.v2#MapSlice
-type orderedConfig struct {
-	URL      string        `yaml:"url"`
-	Packages yaml.MapSlice `yaml:"packages"`
-}
-
 // Package details the options available for each repo
 type Package struct {
 	Repo string `yaml:"repo"`
@@ -28,13 +21,16 @@ type Package struct {
 
 // ensureAlphabetical checks that the packages are listed alphabetically in the configuration.
 func ensureAlphabetical(data []byte) bool {
-	var c orderedConfig
+	// A yaml.MapSlice perservers ordering of keys: https://godoc.org/gopkg.in/yaml.v2#MapSlice
+	var c struct {
+		Packages yaml.MapSlice `yaml:"packages"`
+	}
 
 	if err := yaml.Unmarshal(data, &c); err != nil {
 		return false
 	}
 
-	packageNames := make([]string, len(c.Packages))
+	packageNames := make([]string, 0, len(c.Packages))
 	for _, v := range c.Packages {
 		name, ok := v.Key.(string)
 		if !ok {

--- a/config.go
+++ b/config.go
@@ -60,7 +60,7 @@ func Parse(path string) (*Config, error) {
 	}
 
 	if !ensureAlphabetical(data) {
-		return nil, fmt.Errorf("Packages in %s must be alphabetically ordered.", path)
+		return nil, fmt.Errorf("packages in %s must be alphabetically ordered", path)
 	}
 
 	return &c, err

--- a/config_test.go
+++ b/config_test.go
@@ -42,5 +42,7 @@ packages:
 	defer clean()
 
 	_, err := Parse(path)
-	assert.Error(t, err, "YAML configuration is not listed alphabetically")
+	if assert.Error(t, err, "YAML configuration is not listed alphabetically") {
+		assert.Contains(t, err.Error(), "must be alphabetically ordered")
+	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -42,6 +42,5 @@ packages:
 	defer clean()
 
 	_, err := Parse(path)
-
 	assert.Error(t, err, "YAML configuration is not listed alphabetically")
 }

--- a/config_test.go
+++ b/config_test.go
@@ -27,3 +27,21 @@ packages:
 
 	assert.Equal(t, pkg, Package{Repo: "github.com/grpc/grpc-go"})
 }
+
+func TestNotAlphabetical(t *testing.T) {
+	path, clean := TempFile(t, `
+
+url: google.golang.org
+packages:
+  grpc:
+    repo: github.com/grpc/grpc-go
+  atomic:
+    repo: github.com/uber-go/atomic
+
+`)
+	defer clean()
+
+	_, err := Parse(path)
+
+	assert.EqualError(t, err, "YAML configuration is not listed alphabetically")
+}

--- a/config_test.go
+++ b/config_test.go
@@ -43,5 +43,5 @@ packages:
 
 	_, err := Parse(path)
 
-	assert.EqualError(t, err, "YAML configuration is not listed alphabetically")
+	assert.Error(t, err, "YAML configuration is not listed alphabetically")
 }

--- a/handler.go
+++ b/handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CreateHandler creates a Sally http.Handler
-func CreateHandler(config Config) http.Handler {
+func CreateHandler(config *Config) http.Handler {
 	router := httprouter.New()
 	router.RedirectTrailingSlash = false
 
@@ -29,7 +29,7 @@ func CreateHandler(config Config) http.Handler {
 }
 
 type indexHandler struct {
-	config Config
+	config *Config
 }
 
 func (h indexHandler) Handle(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -54,7 +54,7 @@ var indexTemplate = template.Must(template.New("index").Parse(`
 type packageHandler struct {
 	pkgName string
 	pkg     Package
-	config  Config
+	config  *Config
 }
 
 func (h packageHandler) Handle(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -6,10 +6,10 @@ var config = `
 
 url: go.uber.org
 packages:
-  yarpc:
-    repo: github.com/yarpc/yarpc-go
   thriftrw:
     repo: github.com/thriftrw/thriftrw-go
+  yarpc:
+    repo: github.com/yarpc/yarpc-go
 
 `
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main
+package main // import "go.uber.org/sally"
 
 import (
 	"flag"

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "go.uber.org/sally"
+package main
 
 import (
 	"flag"


### PR DESCRIPTION
This PR:
- Ensures alphabetical ordering in the YAML configuration
- Uses a pointer value for the `Config` in various places
- Adds a new test
- Removes the import comment which would not allow external builds

Closes #20 