### PR TITLE
Add dockerfiles and update makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 vendor
-_tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,5 @@ RUN mkdir -p /go/src/go.uber.org/sally
 WORKDIR /go/src/go.uber.org/sally
 ADD glide.yaml glide.lock /go/src/go.uber.org/sally/
 RUN go get -v github.com/Masterminds/glide && glide install
-RUN go get -v github.com/golang/lint/golint github.com/kisielk/errcheck honnef.co/go/staticcheck/cmd/staticcheck
 ADD . /go/src/go.uber.org/sally/
 CMD ["make", "docker-launch-dev-internal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:1.7.4
-MAINTAINER pedge@uber.com
 
 EXPOSE 8080
 RUN \
-  curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.12.5 > /bin/docker && \
+  curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.12.6 > /bin/docker && \
   chmod +x /bin/docker
 RUN mkdir -p /go/src/go.uber.org/sally
 WORKDIR /go/src/go.uber.org/sally

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.7.4
+MAINTAINER pedge@uber.com
+
+EXPOSE 8080
+RUN \
+  curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.12.5 > /bin/docker && \
+  chmod +x /bin/docker
+RUN mkdir -p /go/src/go.uber.org/sally
+WORKDIR /go/src/go.uber.org/sally
+ADD glide.yaml glide.lock /go/src/go.uber.org/sally/
+RUN go get -v github.com/Masterminds/glide && glide install
+RUN go get -v github.com/golang/lint/golint github.com/kisielk/errcheck
+ADD . /go/src/go.uber.org/sally/
+CMD ["make", "docker-launch-dev-internal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM golang:1.7.4
 
 EXPOSE 8080
 RUN \
-  curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.12.6 > /bin/docker && \
-  chmod +x /bin/docker
+  curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz && \
+  tar --strip-components=1 -xvzf docker-latest.tgz -C /usr/local/bin
 RUN mkdir -p /go/src/go.uber.org/sally
 WORKDIR /go/src/go.uber.org/sally
 ADD glide.yaml glide.lock /go/src/go.uber.org/sally/
 RUN go get -v github.com/Masterminds/glide && glide install
-RUN go get -v github.com/golang/lint/golint github.com/kisielk/errcheck
+RUN go get -v github.com/golang/lint/golint github.com/kisielk/errcheck honnef.co/go/staticcheck/cmd/staticcheck
 ADD . /go/src/go.uber.org/sally/
 CMD ["make", "docker-launch-dev-internal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /go/src/go.uber.org/sally
 ADD glide.yaml glide.lock /go/src/go.uber.org/sally/
 RUN go get -v github.com/Masterminds/glide && glide install
 ADD . /go/src/go.uber.org/sally/
-CMD ["make", "docker-launch-dev-internal"]
+CMD ["make", "run"]

--- a/Dockerfile.sally
+++ b/Dockerfile.sally
@@ -1,0 +1,7 @@
+FROM scratch
+MAINTAINER pedge@uber.com
+
+EXPOSE 8080
+ADD sally.yaml /
+ADD _tmp/sally /
+ENTRYPOINT ["/sally"]

--- a/Dockerfile.sally
+++ b/Dockerfile.sally
@@ -1,5 +1,4 @@
 FROM scratch
-MAINTAINER pedge@uber.com
 
 EXPOSE 8080
 ADD sally.yaml /

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ all: test
 
 .PHONY: vendor-update
 vendor-update:
-	rm -rf vendor
-	go get -d -v -t -u -f ./...
 	go get -v github.com/Masterminds/glide
-	glide create
 	glide update
 
 .PHONY: vendor-install
@@ -27,7 +24,7 @@ install:
 
 .PHONY: lint
 lint:
-	go get -v github.com/golang/lint/golint
+	go install ./vendor/github.com/golang/lint/golint
 	for file in $$(find . -name '*.go' | grep -v '^\./vendor'); do \
 		golint $$file; \
 		if [ -n "$$(golint $$file)" ]; then \
@@ -41,13 +38,13 @@ vet:
 
 .PHONY: errcheck
 errcheck:
-	go get -v github.com/kisielk/errcheck
+	go install ./vendor/github.com/kisielk/errcheck
 	errcheck $(PKGS)
 
 .PHONY: staticcheck
 staticcheck:
-	go get -v honnef.co/go/staticcheck/cmd/staticcheck
-	staticcheck ./...
+	go install ./vendor/honnef.co/go/staticcheck/cmd/staticcheck
+	staticcheck $(PKGS)
 
 .PHONY: pretest
 pretest: lint vet errcheck staticcheck

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,94 @@
-PACKAGES := $(shell glide novendor)
+PKGS := $(shell go list ./... | grep -v go.uber.org/sally/vendor)
+SRCS := $(wildcard *.go)
 
-.PHONY: install
-install:
-	glide --version || go get github.com/Masterminds/glide
+all: test
+
+vendor-update:
+	rm -rf vendor
+	go get -d -v -t -u -f ./...
+	go get -v github.com/Masterminds/glide
+	glide create
+	glide update
+
+vendor-install:
+	go get -v github.com/Masterminds/glide
 	glide install
 
+build:
+	go build $(PKGS)
 
-.PHONY: lint
+install:
+	go install $(PKGS)
+
 lint:
-	go vet $(PACKAGES)
-	$(foreach pkg, $(PACKAGES), golint $(pkg) &&) echo "success"
+	go get -v github.com/golang/lint/golint
+	for file in $$(find . -name '*.go' | grep -v '^\./vendor'); do \
+		golint $$file; \
+		if [ -n "$$(golint $$file)" ]; then \
+			exit 1; \
+		fi; \
+	done
 
+vet:
+	go vet $(PKGS)
 
-.PHONY: test
-test: lint
-	go test -race $(PACKAGES)
+errcheck:
+	go get -v github.com/kisielk/errcheck
+	errcheck $(PKGS)
 
+pretest: lint vet errcheck
 
-.PHONY: run
-run:
-	go build -i && ./sally
+test: pretest
+	go test -race $(PKGS)
+
+clean:
+	go clean -i $(PKGS)
+	rm -rf _tmp
+
+docker-build-dev:
+	docker build -t uber/sally-dev .
+
+docker-test: docker-build-dev
+	docker run uber/sally-dev make test
+
+docker-build-internal:
+	rm -rf _tmp
+	mkdir -p _tmp
+	CGO_ENABLED=0 go build -a -installsuffix cgo -o _tmp/sally $(SRCS)
+	docker build -t uber/sally -f Dockerfile.sally .
+
+docker-build: docker-build-dev
+	docker run -v /var/run/docker.sock:/var/run/docker.sock uber/sally-dev make docker-build-internal
+
+docker-launch-dev-internal: install
+	sally
+
+docker-launch-dev: docker-build-dev
+	docker run -p 8080:8080 uber/sally-dev
+
+docker-launch: docker-build
+	docker run -p 8080:8080 uber/sally
+
+launch: install
+	sally
+
+.PHONY: \
+	all \
+	vendor-update \
+	vendor-install \
+	build \
+	install \
+	lint \
+	vet \
+	errcheck \
+	pretest \
+	test \
+	clean \
+	docker-build-dev \
+	docker-test \
+	docker-build-internal \
+	docker-build \
+	docker-launch-dev-internal \
+	docker-launch-dev \
+	docker-launch \
+	launch

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,6 @@ docker-build-internal:
 docker-build: docker-build-dev
 	docker run -v /var/run/docker.sock:/var/run/docker.sock uber/sally-dev make docker-build-internal
 
-.PHONY: docker-launch-dev-internal
-docker-launch-dev-internal: install
-	sally
-
 .PHONY: docker-launch-dev
 docker-launch-dev: docker-build-dev
 	docker run -p 8080:8080 uber/sally-dev
@@ -90,5 +86,5 @@ docker-launch: docker-build
 	docker run -p 8080:8080 uber/sally
 
 .PHONY: install
-launch: install
+run: install
 	sally

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install:
 .PHONY: lint
 lint:
 	go install ./vendor/github.com/golang/lint/golint
-	for file in $$(find . -name '*.go' | grep -v '^\./vendor'); do \
+	for file in $(SRCS); do \
 		golint $$file; \
 		if [ -n "$$(golint $$file)" ]; then \
 			exit 1; \

--- a/glide.lock
+++ b/glide.lock
@@ -1,27 +1,49 @@
-hash: 8f67008e0ad384b7bab0cf30ee7b6926b7145c5be7e95b6be35163930eb7f7e6
-updated: 2016-10-12T10:19:26.528895463-07:00
+hash: 3d2dd61fbbbb3bcac1d8a9705f3490cf3d7ccc31147ec01662b78a81881ca5a2
+updated: 2017-01-26T13:58:37.214672796+01:00
 imports:
-- name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
-  subpackages:
-  - spew
 - name: github.com/julienschmidt/httprouter
   version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
+- name: gopkg.in/yaml.v2
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  subpackages:
+  - spew
+- name: github.com/golang/lint
+  version: 3390df4df2787994aea98de825b964ac7944b817
+  subpackages:
+  - golint
+- name: github.com/kisielk/errcheck
+  version: db0ca22445717d1b2c51ac1034440e0a2a2de645
+- name: github.com/kisielk/gotool
+  version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
   subpackages:
   - assert
 - name: github.com/yosssi/gohtml
   version: ccf383eafddde21dfe37c6191343813822b30e6b
 - name: golang.org/x/net
-  version: 8058fc7b18f8794d9fc57eee98d64fe2c750e3f1
+  version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
   subpackages:
   - html
   - html/atom
-- name: gopkg.in/yaml.v2
-  version: 31c299268d302dd0aa9a0dcf765a3d58971ac83f
-testImports: []
+- name: golang.org/x/tools
+  version: 0db92ca630c08f00e3ba4b5abea93836ca04b42e
+  subpackages:
+  - go/gcimporter15
+- name: honnef.co/go/lint
+  version: 8807103a5c828099e06f52d70faa05575d24869f
+  subpackages:
+  - lintutil
+- name: honnef.co/go/ssa
+  version: 1cf7f34afde4f3f9cb9f7b15f8f2727ebcaa179a
+- name: honnef.co/go/staticcheck
+  version: b48330f1ed0dd7463407767da164e7f3ee43ad76
+  subpackages:
+  - cmd/staticcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/uber-go/sally
+package: go.uber.org/sally
 import:
 - package: gopkg.in/yaml.v2
 - package: github.com/julienschmidt/httprouter
@@ -6,3 +6,18 @@ import:
 testImport:
 - package: github.com/stretchr/testify
 - package: github.com/yosssi/gohtml
+- package: github.com/golang/lint
+  subpackages:
+    - golint
+- package: golang.org/x/tools
+  subpackages:
+    - go/gcimporter15
+- package: github.com/kisielk/errcheck
+- package: github.com/kisielk/gotool
+- package: honnef.co/go/staticcheck
+  subpackages:
+    - cmd/staticcheck
+- package: honnef.co/go/lint
+  subpackages:
+    - lintutil
+- package: honnef.co/go/ssa

--- a/utils_test.go
+++ b/utils_test.go
@@ -27,7 +27,7 @@ func TempFile(t *testing.T, contents string) (path string, clean func()) {
 	}
 
 	return tmpfile.Name(), func() {
-		os.Remove(tmpfile.Name())
+		_ = os.Remove(tmpfile.Name())
 	}
 }
 


### PR DESCRIPTION
This PR does a few things:

- Adds a development Dockerfile

`Dockerfile` defines a Docker image that can be used for development and for building the production Docker image. This gives a clean state to run development commands in - `make docker-test` should effectively be the SOT for whether or not sally is passing. This is useful in a lot of scenarios - perhaps something was added that was not vendored properly, or one of the linting binaries was compiled on a development branch and is out of date, or anything else. It also makes it possible to drop this repository into Elastic Beanstalk (this is how https://github.com/peter-edge/importserver-go is deployed). Also, it gives a clean environment to compile the production Docker image in - when go panics, it will show the filepaths to files in the stack trace. It's better for these to be `/go/src/...` instead of `/Users/peteredge/src/...` for example. Eventually, this would be nice to use for a CI tool such as Travis, especially if it supports Docker image caching now. Instead of using the Travis environment, we would use this known environment for testing.

- Adds a production Dockerfile to make a production Docker image

`Dockerfile.sally` defines a Docker image that only contains `sally.yaml` and a statically-compiled binary. If we eventually pushed this to Docker Hub or quay.io, this allows for a small Docker image that can also be deployed anywhere. One pain point is the yaml file - right now, someone would need to do the equivalent of:

```bash
# assuming there is a /foo/sally.yaml
docker run -v /foo:/foo uber/sally -yml /foo/sally.yaml
```

We can work on this in the future. This is built within the development Docker image.

- Updates the Makefile

This updates the Makefile to add some more development commands. This is in the style that I generally have used such as https://github.com/peter-edge/importserver-go/blob/master/Makefile, which differs a bit from Uber style. I generally have more verbosity, and rely on exit codes instead of the lack of output to denote linting passing.