### PR TITLE
Split sally into lib package and binary package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PKGS := $(shell go list ./... | grep -v go.uber.org/sally/vendor)
 SRCS := $(wildcard *.go) $(wildcard cmd/sally/*.go)
+MAIN_SRCS := $(wildcard cmd/sally/*.go)
 
 .PHONY: all
 all: test
@@ -70,7 +71,7 @@ docker-test: docker-build-dev
 docker-build-internal:
 	rm -rf _tmp
 	mkdir -p _tmp
-	CGO_ENABLED=0 go build -a -installsuffix cgo -o _tmp/sally $(SRCS)
+	CGO_ENABLED=0 go build -a -installsuffix cgo -o _tmp/sally $(MAIN_SRCS)
 	docker build -t uber/sally -f Dockerfile.scratch .
 
 .PHONY: docker-build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKGS := $(shell go list ./... | grep -v go.uber.org/sally/vendor)
-SRCS := $(wildcard *.go)
+SRCS := $(wildcard *.go) $(wildcard cmd/sally/*.go)
 
 .PHONY: all
 all: test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tiny HTTP server for supporting custom Golang import paths
 
 ## Installation
 
-`go get go.uber.org/sally`
+`go get go.uber.org/sally/cmd/sally`
 
 ## Usage
 

--- a/cmd/sally/main.go
+++ b/cmd/sally/main.go
@@ -1,26 +1,29 @@
-package main // import "go.uber.org/sally"
+package main
 
 import (
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
+
+	"go.uber.org/sally"
+)
+
+var (
+	yml  = flag.String("yml", "sally.yaml", "yaml file to read config from")
+	port = flag.Int("port", 8080, "port to listen and serve on")
 )
 
 func main() {
-	yml := flag.String("yml", "sally.yaml", "yaml file to read config from")
-	port := flag.Int("port", 8080, "port to listen and serve on")
 	flag.Parse()
 
 	log.Printf("Parsing yaml at path: %s\n", *yml)
-	config, err := Parse(*yml)
+	config, err := sally.Parse(*yml)
 	if err != nil {
 		log.Fatalf("Failed to parse %s: %v", *yml, err)
 	}
-
 	log.Printf("Creating HTTP handler with config: %v", config)
-	handler := CreateHandler(config)
-
+	handler := sally.CreateHandler(config)
 	log.Printf(`Starting HTTP handler on ":%d"`, *port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), handler))
 }

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package main
+package sally
 
 import (
 	"fmt"

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-package main
+package sally
 
 import (
 	"testing"

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,4 @@
+/*
+Package sally contains logic to run a golang import server.
+*/
+package sally // import "go.uber.org/sally"

--- a/handler.go
+++ b/handler.go
@@ -1,4 +1,4 @@
-package main
+package sally
 
 import (
 	"fmt"

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,4 +1,4 @@
-package main
+package sally
 
 import "testing"
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,4 +1,4 @@
-package main
+package sally
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
This splits the actual main package into a separate `cmd/sally` package, which is a general standard for golang for non-trivial code that has an associated main package. As sally grows in functionality, it would be nice to separate the library code (which could be used elsewhere as well) from the actual running program (which uses the library code), especially if sally ends up having sub-packages.