### PR TITLE
Cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.7.5
+FROM golang:1.8.1
 
 EXPOSE 8080
 RUN \
   curl -fsSLO https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz && \
   tar --strip-components=1 -xvzf docker-latest.tgz -C /usr/local/bin
-RUN mkdir -p /go/src/go.uber.org/sally
 WORKDIR /go/src/go.uber.org/sally
 ADD glide.yaml glide.lock /go/src/go.uber.org/sally/
 RUN go get -v github.com/Masterminds/glide && glide install

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ errcheck:
 
 .PHONY: staticcheck
 staticcheck:
-	go install ./vendor/honnef.co/go/staticcheck/cmd/staticcheck
+	go install ./vendor/honnef.co/go/tools/cmd/staticcheck
 	staticcheck $(PKGS)
 
 .PHONY: pretest

--- a/config.go
+++ b/config.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
-	"sort"
 
 	"gopkg.in/yaml.v2"
 )
@@ -19,29 +17,6 @@ type Package struct {
 	Repo string `yaml:"repo"`
 }
 
-// ensureAlphabetical checks that the packages are listed alphabetically in the configuration.
-func ensureAlphabetical(data []byte) bool {
-	// A yaml.MapSlice perservers ordering of keys: https://godoc.org/gopkg.in/yaml.v2#MapSlice
-	var c struct {
-		Packages yaml.MapSlice `yaml:"packages"`
-	}
-
-	if err := yaml.Unmarshal(data, &c); err != nil {
-		return false
-	}
-
-	packageNames := make([]string, 0, len(c.Packages))
-	for _, v := range c.Packages {
-		name, ok := v.Key.(string)
-		if !ok {
-			return false
-		}
-		packageNames = append(packageNames, name)
-	}
-
-	return sort.StringsAreSorted(packageNames)
-}
-
 // Parse takes a path to a yaml file and produces a parsed Config
 func Parse(path string) (*Config, error) {
 	var c Config
@@ -53,10 +28,6 @@ func Parse(path string) (*Config, error) {
 
 	if err := yaml.Unmarshal(data, &c); err != nil {
 		return nil, err
-	}
-
-	if !ensureAlphabetical(data) {
-		return nil, fmt.Errorf("packages in %s must be alphabetically ordered", path)
 	}
 
 	return &c, err

--- a/config_test.go
+++ b/config_test.go
@@ -27,22 +27,3 @@ packages:
 
 	assert.Equal(t, pkg, Package{Repo: "github.com/grpc/grpc-go"})
 }
-
-func TestNotAlphabetical(t *testing.T) {
-	path, clean := TempFile(t, `
-
-url: google.golang.org
-packages:
-  grpc:
-    repo: github.com/grpc/grpc-go
-  atomic:
-    repo: github.com/uber-go/atomic
-
-`)
-	defer clean()
-
-	_, err := Parse(path)
-	if assert.Error(t, err, "YAML configuration is not listed alphabetically") {
-		assert.Contains(t, err.Error(), "must be alphabetically ordered")
-	}
-}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3d2dd61fbbbb3bcac1d8a9705f3490cf3d7ccc31147ec01662b78a81881ca5a2
-updated: 2017-01-26T13:58:37.214672796+01:00
+hash: f40b72fb05d549e6f2e232b1a56d75a957d314804f610dba28b07887c5ea5110
+updated: 2017-04-21T14:29:05.464516569-07:00
 imports:
 - name: github.com/julienschmidt/httprouter
   version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
@@ -7,15 +7,15 @@ imports:
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/golang/lint
-  version: 3390df4df2787994aea98de825b964ac7944b817
+  version: cb00e5669539f047b2f4c53a421a01b0c8e172c6
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
-  version: db0ca22445717d1b2c51ac1034440e0a2a2de645
+  version: 23699b7e2cbfdb89481023524954ba2aeff6be90
 - name: github.com/kisielk/gotool
   version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
 - name: github.com/pmezard/go-difflib
@@ -23,27 +23,27 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert
 - name: github.com/yosssi/gohtml
-  version: ccf383eafddde21dfe37c6191343813822b30e6b
+  version: 1d8dc9c914ff4253a3af95c1891d809210245e69
 - name: golang.org/x/net
-  version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
+  version: b400c2eff1badec7022a8c8f5bea058b6315eed7
   subpackages:
   - html
   - html/atom
 - name: golang.org/x/tools
-  version: 0db92ca630c08f00e3ba4b5abea93836ca04b42e
+  version: 1529f889eb4b594d1f047f2fb8d5b3cc85c8f006
   subpackages:
   - go/gcimporter15
 - name: honnef.co/go/lint
-  version: 8807103a5c828099e06f52d70faa05575d24869f
+  version: 9ad746f5a7e0e84de969c026c26693d6b2f0af27
   subpackages:
   - lintutil
 - name: honnef.co/go/ssa
   version: 1cf7f34afde4f3f9cb9f7b15f8f2727ebcaa179a
-- name: honnef.co/go/staticcheck
-  version: b48330f1ed0dd7463407767da164e7f3ee43ad76
+- name: honnef.co/go/tools
+  version: 6c3814a19596cc3f3de23f0442023a5adbb28eb6
   subpackages:
   - cmd/staticcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ testImport:
     - go/gcimporter15
 - package: github.com/kisielk/errcheck
 - package: github.com/kisielk/gotool
-- package: honnef.co/go/staticcheck
+- package: honnef.co/go/tools
   subpackages:
     - cmd/staticcheck
 - package: honnef.co/go/lint

--- a/handler_test.go
+++ b/handler_test.go
@@ -6,10 +6,10 @@ var config = `
 
 url: go.uber.org
 packages:
-  thriftrw:
-    repo: github.com/thriftrw/thriftrw-go
   yarpc:
     repo: github.com/yarpc/yarpc-go
+  thriftrw:
+    repo: github.com/thriftrw/thriftrw-go
 
 `
 


### PR DESCRIPTION
This does a few things:

- Update the golang version in the Dockerfile from 1.7.5 to 1.8.1
- Remove an unneeded `RUN` call in the Dockerfile
- Update the location of the staticcheck tool
- Call glide update
- Do not require packages to be listed alphabetically, and sort them internally instead. The new implementation actually also technically takes care of a bug - golang maps are not defined to be iterated over in insertion order, even though they usually end up doing this, and the Config struct just had a map from package name to Package struct, which was expected to be in sorted order.