### PR TITLE
Update Godoc server to pkg.go.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added support configuring the godoc.org instance used for documentation
+- Added support configuring the godoc server used for documentation
   links.
+
+### Changed
+- Updated default godoc server from `https://godoc.org` to `https://pkg.go.dev`
 
 ## [1.0.1] - 2019-01-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   links.
 
 ### Changed
-- Updated default godoc server from `https://godoc.org` to `https://pkg.go.dev`
+- Updated default godoc server from `https://godoc.org` to `https://pkg.go.dev`.
 
 ## [1.0.1] - 2019-01-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added support configuring the godoc server used for documentation
-  links.
+- Support configuring the godoc server used for documentation links.
 
 ### Changed
 - Updated default godoc server from `https://godoc.org` to `https://pkg.go.dev`.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Create a YAML file with the following structure:
 ```yaml
 # This optional section configures godoc documentation linking.
 godoc:
-  # Instance of godoc.org used for documentation links. Defaults to godoc.org.
-  host: godoc.org
+  # Instance of godoc server used for documentation links. Defaults to pkg.go.dev.
+  host: pkg.go.dev
 
 url: google.golang.org
 packages:

--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const _defaultGodocServer = "godoc.org"
+const _defaultGodocServer = "pkg.go.dev"
 
 // Config represents the structure of the yaml file
 type Config struct {
@@ -27,7 +27,7 @@ type Package struct {
 
 // ensureAlphabetical checks that the packages are listed alphabetically in the configuration.
 func ensureAlphabetical(data []byte) bool {
-	// A yaml.MapSlice perservers ordering of keys: https://godoc.org/gopkg.in/yaml.v2#MapSlice
+	// A yaml.MapSlice perservers ordering of keys: https://pkg.go.dev/gopkg.in/yaml.v2#MapSlice
 	var c struct {
 		Packages yaml.MapSlice `yaml:"packages"`
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -22,7 +22,7 @@ packages:
 	config, err := Parse(path)
 	assert.NoError(t, err)
 
-	assert.Equal(t, config.Godoc.Host, "godoc.org")
+	assert.Equal(t, config.Godoc.Host, "pkg.go.dev")
 	assert.Equal(t, config.URL, "google.golang.org")
 
 	pkg, ok := config.Packages["grpc"]

--- a/handler_test.go
+++ b/handler_test.go
@@ -34,10 +34,10 @@ func TestPackageShouldExist(t *testing.T) {
     <head>
         <meta name="go-import" content="go.uber.org/yarpc git https://github.com/yarpc/yarpc-go">
         <meta name="go-source" content="go.uber.org/yarpc https://github.com/yarpc/yarpc-go https://github.com/yarpc/yarpc-go/tree/master{/dir} https://github.com/yarpc/yarpc-go/tree/master{/dir}/{file}#L{line}">
-        <meta http-equiv="refresh" content="0; url=https://godoc.org/go.uber.org/yarpc">
+        <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/go.uber.org/yarpc">
     </head>
     <body>
-        Nothing to see here. Please <a href="https://godoc.org/go.uber.org/yarpc">move along</a>.
+        Nothing to see here. Please <a href="https://pkg.go.dev/go.uber.org/yarpc">move along</a>.
     </body>
 </html>
 `)
@@ -58,10 +58,10 @@ func TestTrailingSlash(t *testing.T) {
     <head>
         <meta name="go-import" content="go.uber.org/yarpc git https://github.com/yarpc/yarpc-go">
         <meta name="go-source" content="go.uber.org/yarpc https://github.com/yarpc/yarpc-go https://github.com/yarpc/yarpc-go/tree/master{/dir} https://github.com/yarpc/yarpc-go/tree/master{/dir}/{file}#L{line}">
-        <meta http-equiv="refresh" content="0; url=https://godoc.org/go.uber.org/yarpc/">
+        <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/go.uber.org/yarpc/">
     </head>
     <body>
-        Nothing to see here. Please <a href="https://godoc.org/go.uber.org/yarpc/">move along</a>.
+        Nothing to see here. Please <a href="https://pkg.go.dev/go.uber.org/yarpc/">move along</a>.
     </body>
 </html>
 `)
@@ -75,10 +75,10 @@ func TestDeepImports(t *testing.T) {
     <head>
         <meta name="go-import" content="go.uber.org/yarpc git https://github.com/yarpc/yarpc-go">
         <meta name="go-source" content="go.uber.org/yarpc https://github.com/yarpc/yarpc-go https://github.com/yarpc/yarpc-go/tree/master{/dir} https://github.com/yarpc/yarpc-go/tree/master{/dir}/{file}#L{line}">
-        <meta http-equiv="refresh" content="0; url=https://godoc.org/go.uber.org/yarpc/heeheehee">
+        <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/go.uber.org/yarpc/heeheehee">
     </head>
     <body>
-        Nothing to see here. Please <a href="https://godoc.org/go.uber.org/yarpc/heeheehee">move along</a>.
+        Nothing to see here. Please <a href="https://pkg.go.dev/go.uber.org/yarpc/heeheehee">move along</a>.
     </body>
 </html>
 `)
@@ -90,10 +90,10 @@ func TestDeepImports(t *testing.T) {
     <head>
         <meta name="go-import" content="go.uber.org/yarpc git https://github.com/yarpc/yarpc-go">
         <meta name="go-source" content="go.uber.org/yarpc https://github.com/yarpc/yarpc-go https://github.com/yarpc/yarpc-go/tree/master{/dir} https://github.com/yarpc/yarpc-go/tree/master{/dir}/{file}#L{line}">
-        <meta http-equiv="refresh" content="0; url=https://godoc.org/go.uber.org/yarpc/heehee/hawhaw">
+        <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/go.uber.org/yarpc/heehee/hawhaw">
     </head>
     <body>
-        Nothing to see here. Please <a href="https://godoc.org/go.uber.org/yarpc/heehee/hawhaw">move along</a>.
+        Nothing to see here. Please <a href="https://pkg.go.dev/go.uber.org/yarpc/heehee/hawhaw">move along</a>.
     </body>
 </html>
 `)


### PR DESCRIPTION
Update our default Godoc server from `https://godoc.org` to the shiny, new `https://pkg.go.dev/`

Closes #39, T4832833