### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.1.0 - 2020-02-13
+## [1.1.0] - 2020-02-13
 ### Added
 - Support configuring the godoc server used for documentation links.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 1.1.0 - 2020-02-13
 ### Added
 - Support configuring the godoc server used for documentation links.
 
@@ -20,5 +20,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial tagged release.
 
-[Unreleased]: https://github.com/uber-go/sally/compare/v1.0.1...HEAD
+[1.1.0]: https://github.com/uber-go/sally/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/uber-go/sally/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
Release v1.1.0 with the following changes:

Added
- Support configuring the godoc server used for documentation links.

Changed
- Updated default godoc server from `https://godoc.org` to `https://pkg.go.dev`.