### PR TITLE
Use Go 1.17 to test and build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,22 +11,16 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ["1.15.x", "1.16.x"]
-        include:
-        - go: 1.16.x
-          latest: true
 
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go }}
+        go-version: 1.17.x
 
     - name: Checkout code
       uses: actions/checkout@v2
-      
+
     - name: Load cached dependencies
       uses: actions/cache@v1
       with:
@@ -34,6 +28,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+
     - name: Lint
       if: matrix.latest
       run: make lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.17
 
 EXPOSE 8080
 RUN \


### PR DESCRIPTION
sally is not a library, so there's no reason to test it with two
versions of Go.

Use the latest version of Go to build and test it.
