### PR TITLE
badge: Use pkg.go.dev badge

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
                             </td>
                             <td>
                                 <a href="//{{ $.Godoc.Host }}/{{ $importPath }}">
-                                    <img src="//img.shields.io/badge/godoc-reference-blue?style=for-the-badge" alt="GoDoc" />
+                                    <img src="//pkg.go.dev/badge/{{ $importPath }}.svg" alt="Go Reference" />
                                 </a>
                             </td>
                         </tr>


### PR DESCRIPTION
When we originally switched to pkg.go.dev (#40),
it did not offer documentation badges so we relied on a third-party
service.

That's no longer true (https://pkg.go.dev/badge) so we can use
pkg.go.dev's more "on-brand" badges for this.

Screenshot:
<img width="876" alt="image" src="https://user-images.githubusercontent.com/41730/168866385-5cb1d131-e99d-4ac3-b99e-ac543a44cece.png">

