### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- No changes yet.
+## [1.2.0] - 2022-05-17
+### Added
+- Packages now support specifying branches for target repositories with the
+  `branch` field.
+- Packages can now override the `url` on a per-package basis with the `url`
+  field.
+
+### Changed
+- Use documentation badges from https://pkg.go.dev.
+
+Thanks to @lucianonooijen, @jpbede, and @sullivtr for their contributions to
+this release.
+
+[1.2.0]: https://github.com/uber-go/sally/compare/v1.1.1...v1.2.0
 
 ## [1.1.1] - 2020-03-02
 ### Fixed
 - Fixed godoc badge image.
+
+[1.1.1]: https://github.com/uber-go/sally/compare/v1.1.0...v1.1.1
 
 ## [1.1.0] - 2020-02-13
 ### Added
@@ -18,16 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated default godoc server from `https://godoc.org` to `https://pkg.go.dev`.
 
+[1.1.0]: https://github.com/uber-go/sally/compare/v1.0.1...v1.1.0
+
 ## [1.0.1] - 2019-01-03
 ### Fixed
 - Templates are now bundled with the binary rather than requiring a copy of the
   sally source.
 
+[1.0.1]: https://github.com/uber-go/sally/compare/v1.0.0...v1.0.1
+
 ## 1.0.0 - 2019-01-03
 
 - Initial tagged release.
-
-[Unreleased]: https://github.com/uber-go/sally/compare/v1.1.1...HEAD
-[1.1.1]: https://github.com/uber-go/sally/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/uber-go/sally/compare/v1.0.1...v1.1.0
-[1.0.1]: https://github.com/uber-go/sally/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
This releases Sally v1.2.0 with several changes and a couple community
contributions.

In updating the changelog, I moved the reference links from the bottom
to the section for each version because otherwise it's easy to forget to
add these.
