### PR TITLE
ci: Use Go 1.19 and update GH actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,21 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18.x
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    - name: Load cached dependencies
-      uses: actions/cache@v1
+    - name: Setup Go
+      uses: actions/setup-go@v3
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version: 1.19.x
+        cache: true
 
     - name: Lint
       run: make lint

--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -55,7 +55,7 @@ func ensureAlphabetical(data []byte) bool {
 func Parse(path string) (*Config, error) {
 	var c Config
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -3,9 +3,11 @@ package templates
 import _ "embed" // needed for go:embed
 
 // Index holds the contents of the index.html template.
+//
 //go:embed index.html
 var Index string
 
 // Package holds the contents of the package.html template.
+//
 //go:embed package.html
 var Package string


### PR DESCRIPTION
This updates sally to build and test against Go 1.19.

Additionally, this upgrades the GitHub Action versions
for checkout and setup-go.
One of the features in setup-go v3 is that caching is built-in
and opted-into with `cache: true`.

Non-CI changes: gofmt, drop ioutil
