### PR TITLE
Fix lint error issues

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,7 +13,7 @@ import (
 // TempFile persists contents and returns the path and a clean func
 func TempFile(t *testing.T, contents string) (path string, clean func()) {
 	content := []byte(contents)
-	tmpfile, err := ioutil.TempFile("", "sally-tmp")
+	tmpfile, err := os.CreateTemp("", "sally-tmp")
 	if err != nil {
 		t.Fatal("Unable to create tmpfile", err)
 	}


### PR DESCRIPTION
Since upgrading to Go 1.19 we are seeing linter error due to usage of the deprecated io/ioutil package.

This removes the usage of io/ioutil package.