### PR TITLE
config: Don't require packages to be alphabetical

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
 
-const _defaultGodocServer = "pkg.go.dev"
-const _defaultBranch = "master"
+const (
+	_defaultGodocServer = "pkg.go.dev"
+	_defaultBranch      = "master"
+)
 
 // Config represents the structure of the yaml file
 type Config struct {
@@ -28,29 +28,6 @@ type Package struct {
 	URL    string `yaml:"url"`
 }
 
-// ensureAlphabetical checks that the packages are listed alphabetically in the configuration.
-func ensureAlphabetical(data []byte) bool {
-	// A yaml.MapSlice perservers ordering of keys: https://pkg.go.dev/gopkg.in/yaml.v2#MapSlice
-	var c struct {
-		Packages yaml.MapSlice `yaml:"packages"`
-	}
-
-	if err := yaml.Unmarshal(data, &c); err != nil {
-		return false
-	}
-
-	packageNames := make([]string, 0, len(c.Packages))
-	for _, v := range c.Packages {
-		name, ok := v.Key.(string)
-		if !ok {
-			return false
-		}
-		packageNames = append(packageNames, name)
-	}
-
-	return sort.StringsAreSorted(packageNames)
-}
-
 // Parse takes a path to a yaml file and produces a parsed Config
 func Parse(path string) (*Config, error) {
 	var c Config
@@ -62,10 +39,6 @@ func Parse(path string) (*Config, error) {
 
 	if err := yaml.Unmarshal(data, &c); err != nil {
 		return nil, err
-	}
-
-	if !ensureAlphabetical(data) {
-		return nil, fmt.Errorf("packages in %s must be alphabetically ordered", path)
 	}
 
 	if c.Godoc.Host == "" {

--- a/config_test.go
+++ b/config_test.go
@@ -106,22 +106,3 @@ packages:
 		})
 	}
 }
-
-func TestNotAlphabetical(t *testing.T) {
-	path, clean := TempFile(t, `
-
-url: google.golang.org
-packages:
-  grpc:
-    repo: github.com/grpc/grpc-go
-  atomic:
-    repo: github.com/uber-go/atomic
-
-`)
-	defer clean()
-
-	_, err := Parse(path)
-	if assert.Error(t, err, "YAML configuration is not listed alphabetically") {
-		assert.Contains(t, err.Error(), "must be alphabetically ordered")
-	}
-}


### PR DESCRIPTION
The configuration parser requries that
entries in the 'packages' section
are in alphabetical order.

It will fail parsing if that's not the case,
even if the configuration is otherwise valid.

This seems like an unnecessary artificial limitation.
Enforcing such a convention should be the user's choice.

This change deletes this limitation.

---

Feel free to close if you feel that this restriction adds value.
