### PR TITLE
template: Use a more fluid layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- Use a fluid layout for the index page.
+  This renders better on narrow screens.
 
 [Unreleased]: https://github.com/uber-go/sally/compare/v1.2.0...HEAD
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,38 +3,48 @@
     <head>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css" />
     </head>
+    <style>
+        .separator {
+            margin: 0.25em 0;
+        }
+
+        /* On narrow screens, switch to inline headers. */
+        .table-header { display: none; }
+        .inline-header { font-weight: bold; }
+        @media (min-width: 550px) {
+            .table-header { display: block; }
+            .inline-header { display: none; }
+        }
+    </style>
     <body>
         <div class="container">
-            <div class="row">
-                <table class="u-full-width">
-                    <thead>
-                        <tr>
-                            <th>Package</th>
-                            <th>Source</th>
-                            <th>Documentation</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {{ range $key, $value := .Packages }}
-                        {{ $importPath := printf "%v/%v" $.URL $key }}
-                        {{ if ne $value.URL "" }}
-                            {{ $importPath = printf "%v/%v" $value.URL $key }}
-                        {{ end }}
-                        <tr>
-                            <td>{{ $importPath }}</td>
-                            <td>
-                                <a href="//{{ $value.Repo }}">{{ $value.Repo }}</a>
-                            </td>
-                            <td>
-                                <a href="//{{ $.Godoc.Host }}/{{ $importPath }}">
-                                    <img src="//pkg.go.dev/badge/{{ $importPath }}.svg" alt="Go Reference" />
-                                </a>
-                            </td>
-                        </tr>
-                        {{ end }}
-                    </tbody>
-                </table>
+            <div class="row table-header">
+                <div class="five columns"><strong>Package</strong></div>
+                <div class="five columns"><strong>Source</strong></div>
+                <div class="two columns"><strong>Documentation</strong></div>
             </div>
+            {{ range $key, $value := .Packages }}
+                {{ $importPath := printf "%v/%v" $.URL $key }}
+                {{ if ne $value.URL "" }}
+                    {{ $importPath = printf "%v/%v" $value.URL $key }}
+                {{ end }}
+                <hr class="separator">
+                <div class="row">
+                    <div class="five columns">
+                        <span class="inline-header">Package:</span>
+                        {{ $importPath }}
+                    </div>
+                    <div class="five columns">
+                        <span class="inline-header">Source:</span>
+                        <a href="//{{ $value.Repo }}">{{ $value.Repo }}</a>
+                    </div>
+                    <div class="two columns">
+                        <a href="//{{ $.Godoc.Host }}/{{ $importPath }}">
+                            <img src="//pkg.go.dev/badge/{{ $importPath }}.svg" alt="Go Reference" />
+                        </a>
+                    </div>
+                </div>
+            {{ end }}
         </div>
     </body>
 </html>


### PR DESCRIPTION
Instead of using a table, take advantage of the grid layout.
We still print a table of sorts,
but it's more fluid in appearance based on width of the screen.

On narrower screens, we'll show a listing
where each item has a description label next to it
rather than at the top.

---

**Demo**

Before:
[before.webm](https://user-images.githubusercontent.com/41730/213947951-9a5732d7-bad2-4037-9a20-659acf5aa471.webm)

After:
[after.webm](https://user-images.githubusercontent.com/41730/213947966-cad30ca0-2946-4c16-81af-8c037a3c9053.webm)