### PR TITLE
Add support for package descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- Use a fluid layout for the index page.
+  This renders better on narrow screens.
 
 [Unreleased]: https://github.com/uber-go/sally/compare/v1.2.0...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add an optional `description` field to packages.
+
 ### Changed
 - Use a fluid layout for the index page.
   This renders better on narrow screens.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ packages:
     # Defaults to "master".
     branch: master
 
+    # Optional description of the package.
+    description: A fast, structured-logging library.
+
     # Alternative base URL instead of the value configured at the top-level.
     # This is useful if the same sally instance is
     # hosted behind multiple base URLs.

--- a/config.go
+++ b/config.go
@@ -26,6 +26,8 @@ type Package struct {
 	Repo   string `yaml:"repo"`
 	Branch string `yaml:"branch"`
 	URL    string `yaml:"url"`
+
+	Desc string `yaml:"description"` // plain text only
 }
 
 // ensureAlphabetical checks that the packages are listed alphabetically in the configuration.

--- a/handler_test.go
+++ b/handler_test.go
@@ -17,6 +17,7 @@ packages:
   zap:
     url: go.uberalt.org
     repo: github.com/uber-go/zap
+    description: A fast, structured logging library.
 
 `
 
@@ -27,6 +28,7 @@ func TestIndex(t *testing.T) {
 	body := rr.Body.String()
 	assert.Contains(t, body, "github.com/thriftrw/thriftrw-go")
 	assert.Contains(t, body, "github.com/yarpc/yarpc-go")
+	assert.Contains(t, body, "A fast, structured logging library.")
 }
 
 func TestPackageShouldExist(t *testing.T) {

--- a/sally.yaml
+++ b/sally.yaml
@@ -3,5 +3,6 @@ url: go.uber.org
 packages:
   thriftrw:
     repo: github.com/thriftrw/thriftrw-go
+    description: A customizable implementation of Thrift.
   yarpc:
     repo: github.com/yarpc/yarpc-go

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,38 +3,48 @@
     <head>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css" />
     </head>
+    <style>
+        .separator {
+            margin: 0.25em 0;
+        }
+
+        /* On narrow screens, switch to inline headers. */
+        .table-header { display: none; }
+        .inline-header { font-weight: bold; }
+        @media (min-width: 550px) {
+            .table-header { display: block; }
+            .inline-header { display: none; }
+        }
+    </style>
     <body>
         <div class="container">
-            <div class="row">
-                <table class="u-full-width">
-                    <thead>
-                        <tr>
-                            <th>Package</th>
-                            <th>Source</th>
-                            <th>Documentation</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {{ range $key, $value := .Packages }}
-                        {{ $importPath := printf "%v/%v" $.URL $key }}
-                        {{ if ne $value.URL "" }}
-                            {{ $importPath = printf "%v/%v" $value.URL $key }}
-                        {{ end }}
-                        <tr>
-                            <td>{{ $importPath }}</td>
-                            <td>
-                                <a href="//{{ $value.Repo }}">{{ $value.Repo }}</a>
-                            </td>
-                            <td>
-                                <a href="//{{ $.Godoc.Host }}/{{ $importPath }}">
-                                    <img src="//pkg.go.dev/badge/{{ $importPath }}.svg" alt="Go Reference" />
-                                </a>
-                            </td>
-                        </tr>
-                        {{ end }}
-                    </tbody>
-                </table>
+            <div class="row table-header">
+                <div class="five columns"><strong>Package</strong></div>
+                <div class="five columns"><strong>Source</strong></div>
+                <div class="two columns"><strong>Documentation</strong></div>
             </div>
+            {{ range $key, $value := .Packages }}
+                {{ $importPath := printf "%v/%v" $.URL $key }}
+                {{ if ne $value.URL "" }}
+                    {{ $importPath = printf "%v/%v" $value.URL $key }}
+                {{ end }}
+                <hr class="separator">
+                <div class="row">
+                    <div class="five columns">
+                        <span class="inline-header">Package:</span>
+                        {{ $importPath }}
+                    </div>
+                    <div class="five columns">
+                        <span class="inline-header">Source:</span>
+                        <a href="//{{ $value.Repo }}">{{ $value.Repo }}</a>
+                    </div>
+                    <div class="two columns">
+                        <a href="//{{ $.Godoc.Host }}/{{ $importPath }}">
+                            <img src="//pkg.go.dev/badge/{{ $importPath }}.svg" alt="Go Reference" />
+                        </a>
+                    </div>
+                </div>
+            {{ end }}
         </div>
     </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
         .separator {
             margin: 0.25em 0;
         }
+        .description { color: #666; }
 
         /* On narrow screens, switch to inline headers. */
         .table-header { display: none; }
@@ -44,6 +45,16 @@
                         </a>
                     </div>
                 </div>
+                {{ with .Desc }}
+                    <div class="row">
+                        <div class="one column">
+                            <!-- indent -->
+                        </div>
+                        <div class="eleven columns description">
+                            {{ . }}
+                        </div>
+                    </div>
+                {{ end }}
             {{ end }}
         </div>
     </body>


### PR DESCRIPTION
Packages may now optionally specify a description.
If specified, this is printed below the package information,
indented one column to make it stand out.

Depends on #67

---
Preview:
![image](https://user-images.githubusercontent.com/41730/213948800-419eaa8a-e7d9-415a-b51a-b7300456aede.png)

Resizing:
[description.webm](https://user-images.githubusercontent.com/41730/213948849-55201550-f8d0-4436-81ea-28e977a2c3e1.webm)

---

This change is stacked on top of #67.
It will show a duplicate commit until that PR is merged and this is rebased.
