### PR TITLE
Drop gohtml dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/stretchr/testify v1.8.1
-	github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8
+	golang.org/x/net v0.5.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -13,7 +13,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8 h1:OlIHDBRrlQk8fHa662oG2gzOO/ixBRU9sLht/M9kzK0=
-github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8/go.mod h1:+ccdNT0xMY1dtc5XBxumbYfOUhmduiGudqaDgD2rVRE=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=
+golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/yosssi/gohtml"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/html"
 )
 
 // TempFile persists contents and returns the path and a clean func
@@ -61,5 +64,14 @@ func CallAndRecord(t *testing.T, config string, uri string) *httptest.ResponseRe
 // AssertResponse normalizes and asserts the body from rr against want
 func AssertResponse(t *testing.T, rr *httptest.ResponseRecorder, code int, want string) {
 	assert.Equal(t, rr.Code, code)
-	assert.Equal(t, gohtml.Format(want), gohtml.Format(rr.Body.String()))
+	assert.Equal(t, reformatHTML(t, want), reformatHTML(t, rr.Body.String()))
+}
+
+func reformatHTML(t *testing.T, s string) string {
+	n, err := html.Parse(strings.NewReader(s))
+	require.NoError(t, err)
+
+	var buff bytes.Buffer
+	require.NoError(t, html.Render(&buff, n))
+	return buff.String()
 }


### PR DESCRIPTION
This dependency is used to format and compare HTML.
An additional dependency isn't needed;
we can use the existing (previously transitive) x/net package
to reformat and compare the HTML.
