### PR TITLE
Drop httprouter dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module go.uber.org/sally
 go 1.18
 
 require (
-	github.com/julienschmidt/httprouter v1.3.0
 	github.com/stretchr/testify v1.8.1
 	github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var config = `
@@ -117,4 +122,45 @@ func TestPackageLevelURL(t *testing.T) {
     </body>
 </html>
 `)
+}
+
+func TestPostRejected(t *testing.T) {
+	t.Parallel()
+
+	h := CreateHandler(&Config{
+		URL: "go.uberalt.org",
+		Packages: map[string]Package{
+			"zap": {
+				Repo: "github.com/uber-go/zap",
+			},
+		},
+	})
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	tests := []struct {
+		desc string
+		path string
+	}{
+		{desc: "index", path: "/"},
+		{desc: "package", path: "/zap"},
+		{desc: "subpackage", path: "/zap/zapcore"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := http.Post(srv.URL+tt.path, "text/plain", strings.NewReader("foo"))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			body, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, http.StatusNotFound, res.StatusCode,
+				"expected 404, got:\n%s", string(body))
+		})
+	}
 }


### PR DESCRIPTION
This drops the third-party HTTP router dependency.
This dependency wasn't strictly necessary
since our routing needs are quite basic:

- `/$name` and `/$name/*` for all registered packages
- `/` for root

This is easily accomplished with `http.ServeMux`:

- register `/$name` and `/$name/`.
  The latter will receive all subpackage requests.
- register `/` and reject anything that isn't for exactly `/`.
