### PR TITLE
Add minimal Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# This image provides the sally binary.
+# It does not include a sally configuration.
+# A /sally.yaml file is required for this to run.
+
+FROM golang:1.19-alpine
+
+COPY . /build
+WORKDIR /build
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o sally go.uber.org/sally
+
+FROM scratch
+COPY --from=0 /build/sally /sally
+EXPOSE 8080
+WORKDIR /
+CMD ["/sally"]


### PR DESCRIPTION
Adds a Dockerfile that builds sally using a phased Docker build.
The first phase builds sally,
and the second phase publishes a scratch image
with just sally.

If Uber publishes this to a container registry,
a user can use it like so:

    % vim sally.yaml # create a sally yaml
    % cat > Dockerfile
    FROM sally:latest
    COPY sally.yaml /sally.yaml
    % docker build .

Even without publishing, this provides an example
of how to build sally for deployment.

Testing:
I verified the instructions above locally
by tagging locally with:

    % docker build -t sally:latest

I'm also using a variation of this Dockerfile in production
right now for my own hosted instance of sally.
