### PR TITLE
ci: Publish Docker image to ghcr.io on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Publish Docker Image
+
+on:
+  # Runs when a new release is tagged.
+  release:
+    types: [published]
+
+  # Or when we manually run it from the UI.
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # This action inspects the GitHub event metadata
+      # and fills tags and labels (e.g. 'latest')
+      # needed for the build step.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Log into Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,3 +31,17 @@ jobs:
 
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v1
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          context: .

--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ to serve vanity import paths for Go modules.
 
 ## Installation
 
+To build sally from source, use:
+
 ```bash
 go install go.uber.org/sally@latest
 ```
+
+Alternatively, get a pre-built Docker image from
+https://github.com/uber-go/sally/pkgs/container/sally.
 
 ## Usage
 


### PR DESCRIPTION
Adds a workflow that builds and publishes a Docker image
to ghcr.io based on the Dockerfile in the root of the repository.

This will become available at
https://github.com/uber-go/sally/pkgs/container/sally.
Users will be able to import it by using `ghcr.io/uber-go/sally:$tag`
with `docker pull` or in the `FROM` clause of their own Docker file.

As a test for this, I published it manually to my own fork.
The image is at https://github.com/abhinav/sally/pkgs/container/sally.
With that, I ran the following Dockerfile:

    FROM ghcr.io/abhinav/sally:master
    COPY sally.yaml /

And it worked as expected.

Based on instructions at
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
with help from https://docs.docker.com/build/ci/github-actions/.

Note that this DOES NOT publish the image to DockerHub
because that requires setting up DockerHub account tokens
which I don't have access to.
This job can be adjusted to publish to DockerHub as well as ghcr in the future
using instructions at:

- https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub-and-github-packages
- https://docs.docker.com/build/ci/github-actions/push-multi-registries/
