### PR TITLE
config: Rename Package to PackageConfig, add docs

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,22 +12,51 @@ const (
 	_defaultBranch      = "master"
 )
 
-// Config represents the structure of the yaml file
+// Config defines the configuration for a Sally server.
 type Config struct {
-	URL      string             `yaml:"url"`
-	Packages map[string]Package `yaml:"packages"`
-	Godoc    struct {
-		Host string `yaml:"host"`
-	} `yaml:"godoc"`
+	// URL is the base URL for all vanity imports.
+	URL string `yaml:"url"` // required
+
+	// Packages is a map of package name to package details.
+	Packages map[string]PackageConfig `yaml:"packages"`
+
+	// Godoc specifies where to redirect to for documentation.
+	Godoc GodocConfig `yaml:"godoc"`
 }
 
-// Package details the options available for each repo
-type Package struct {
-	Repo   string `yaml:"repo"`
-	Branch string `yaml:"branch"`
-	URL    string `yaml:"url"`
+// GodocConfig is the configuration for the documentation server.
+type GodocConfig struct {
+	// Host is the hostname of the documentation server.
+	//
+	// Defaults to pkg.go.dev.
+	Host string `yaml:"host"`
+}
 
-	Desc string `yaml:"description"` // plain text only
+// PackageConfig is the configuration for a single Go module
+// that is served by Sally.
+type PackageConfig struct {
+	// Repo is the URL to the Git repository for the module
+	// without the https:// prefix.
+	// This URL must serve the Git HTTPS protocol.
+	//
+	// For example, "github.com/uber-go/sally".
+	Repo string `yaml:"repo"` // required
+
+	// Branch is the default branch for the repository
+	// when no version is specified.
+	//
+	// Defaults to master.
+	Branch string `yaml:"branch"`
+	// NB: This is no longer necessary.
+	// https://github.com/uber-go/sally/issues/83
+
+	// URL is the base URL of the vanity import for this module.
+	//
+	// Defaults to the URL specified in the top-level config.
+	URL string `yaml:"url"`
+
+	// Desc is a plain text description of this module.
+	Desc string `yaml:"description"`
 }
 
 // Parse takes a path to a yaml file and produces a parsed Config

--- a/config_test.go
+++ b/config_test.go
@@ -29,7 +29,7 @@ packages:
 	pkg, ok := config.Packages["grpc"]
 	assert.True(t, ok)
 
-	assert.Equal(t, pkg, Package{Repo: "github.com/grpc/grpc-go", Branch: "main"})
+	assert.Equal(t, pkg, PackageConfig{Repo: "github.com/grpc/grpc-go", Branch: "main"})
 }
 
 func TestParseDefaultBranch(t *testing.T) {
@@ -48,7 +48,7 @@ packages:
 
 	pkg, ok := config.Packages["grpc"]
 	assert.True(t, ok)
-	assert.Equal(t, pkg, Package{Repo: "github.com/grpc/grpc-go", Branch: "master"})
+	assert.Equal(t, pkg, PackageConfig{Repo: "github.com/grpc/grpc-go", Branch: "master"})
 }
 
 func TestParsePackageLevelURL(t *testing.T) {
@@ -102,7 +102,7 @@ packages:
 
 			pkg, ok := config.Packages["grpc"]
 			assert.True(t, ok)
-			assert.Equal(t, Package{Repo: "github.com/grpc/grpc-go", Branch: "master"}, pkg)
+			assert.Equal(t, PackageConfig{Repo: "github.com/grpc/grpc-go", Branch: "master"}, pkg)
 		})
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -54,8 +54,8 @@ func (h *indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type packageHandler struct {
+	pkg     PackageConfig
 	pkgName string
-	pkg     Package
 	config  *Config
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -131,7 +131,7 @@ func TestPostRejected(t *testing.T) {
 
 	h := CreateHandler(&Config{
 		URL: "go.uberalt.org",
-		Packages: map[string]Package{
+		Packages: map[string]PackageConfig{
 			"zap": {
 				Repo: "github.com/uber-go/zap",
 			},


### PR DESCRIPTION
Renames the Package struct to PackageConfig
to make it clear that it is a configuration struct.

This differentiation will help disconnect
the configuration-level representation
from the runtime representation of this information.

This patch also adds documentation to the config package
that was previously missing.