### PR TITLE
Remove branch from PackageConfig struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	_defaultGodocServer = "pkg.go.dev"
-	_defaultBranch      = "master"
 )
 
 // Config defines the configuration for a Sally server.
@@ -42,14 +41,6 @@ type PackageConfig struct {
 	// For example, "github.com/uber-go/sally".
 	Repo string `yaml:"repo"` // required
 
-	// Branch is the default branch for the repository
-	// when no version is specified.
-	//
-	// Defaults to master.
-	Branch string `yaml:"branch"`
-	// NB: This is no longer necessary.
-	// https://github.com/uber-go/sally/issues/83
-
 	// URL is the base URL of the vanity import for this module.
 	//
 	// Defaults to the URL specified in the top-level config.
@@ -80,14 +71,6 @@ func Parse(path string) (*Config, error) {
 		host = strings.TrimPrefix(host, "http://")
 		host = strings.TrimSuffix(host, "/")
 		c.Godoc.Host = host
-	}
-
-	// set default branch
-	for v, p := range c.Packages {
-		if p.Branch == "" {
-			p.Branch = _defaultBranch
-			c.Packages[v] = p
-		}
 	}
 
 	return &c, err

--- a/config_test.go
+++ b/config_test.go
@@ -29,26 +29,7 @@ packages:
 	pkg, ok := config.Packages["grpc"]
 	assert.True(t, ok)
 
-	assert.Equal(t, pkg, PackageConfig{Repo: "github.com/grpc/grpc-go", Branch: "main"})
-}
-
-func TestParseDefaultBranch(t *testing.T) {
-	path, clean := TempFile(t, `
-
-url: google.golang.org
-packages:
-  grpc:
-    repo: github.com/grpc/grpc-go
-
-`)
-	defer clean()
-
-	config, err := Parse(path)
-	assert.NoError(t, err)
-
-	pkg, ok := config.Packages["grpc"]
-	assert.True(t, ok)
-	assert.Equal(t, pkg, PackageConfig{Repo: "github.com/grpc/grpc-go", Branch: "master"})
+	assert.Equal(t, pkg, PackageConfig{Repo: "github.com/grpc/grpc-go"})
 }
 
 func TestParsePackageLevelURL(t *testing.T) {
@@ -102,7 +83,7 @@ packages:
 
 			pkg, ok := config.Packages["grpc"]
 			assert.True(t, ok)
-			assert.Equal(t, PackageConfig{Repo: "github.com/grpc/grpc-go", Branch: "master"}, pkg)
+			assert.Equal(t, PackageConfig{Repo: "github.com/grpc/grpc-go"}, pkg)
 		})
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -83,9 +83,6 @@ type packageHandler struct {
 	// For example, "github.com/uber-go/zap".
 	gitURL string
 
-	// Default branch of the Git repository.
-	defaultBranch string
-
 	// Canonical import path for the package.
 	canonicalURL string
 }
@@ -98,11 +95,10 @@ func newPackageHandler(cfg *Config, name string, pkg PackageConfig) *packageHand
 	canonicalURL := fmt.Sprintf("%s/%s", baseURL, name)
 
 	return &packageHandler{
-		godocHost:     cfg.Godoc.Host,
-		name:          name,
-		canonicalURL:  canonicalURL,
-		gitURL:        pkg.Repo,
-		defaultBranch: pkg.Branch,
+		godocHost:    cfg.Godoc.Host,
+		name:         name,
+		canonicalURL: canonicalURL,
+		gitURL:       pkg.Repo,
 	}
 }
 


### PR DESCRIPTION
With #92, branch is no longer necessary from PackageConfig struct since go-source tag was removed.

This removes Branch field from PackageConfig.