### PR TITLE
ci: Update actions

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository_owner == 'uber-go'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: FOSSA analysis
         uses: fossas/fossa-action@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.20.x
         cache: true
@@ -30,7 +30,7 @@ jobs:
       run: make cover
 
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the checkout, setup-go, and codecov GitHub Actions.

Supersedes #88, #89, #90
