### PR TITLE
Update fossa action to v1.1.0

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: FOSSA analysis
-        uses: fossas/fossa-action@v1
+        uses: fossas/fossa-action@v1.1.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
 


### PR DESCRIPTION
Update fossa action to v1.1.0

The FOSSA check has been failing for a while with
fossa-actions@v1 Error: Input required and not supplied: api-key

This has caused the dependabot queue to backup, we also can't merge them
manually in sally because this check is required.

Updating the version seems to cause the check to run successfully again.

Other repositories have run into the same issue
ref: https://github.com/getsentry/self-hosted/issues/1351