### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.5.0]
 ### Added
 - Generate a package listing for sub-paths
-  that match a subset of the known packages.
+  that match a subset of the known packages. (#120)
+### Changed
+- Use golangci-lint for linting. (#121)
+
+[1.5.0]: https://github.com/uber-go/sally/compare/v1.4.0...v1.5.0
 
 ## [1.4.0]
 ### Added


### PR DESCRIPTION
### Added
- Generate a package listing for sub-paths
  that match a subset of the known packages. (#120)

### Changed
- Use golangci-lint for linting. (#121)