### PR TITLE
fix: documentation URL in index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
                         <a href="//{{ .GitURL }}">{{ .GitURL }}</a>
                     </div>
                     <div class="two columns">
-                        <a href="//{{ .DocURL }}">
+                        <a href="{{ .DocURL }}">
                             <img src="//pkg.go.dev/badge/{{ .ModulePath }}.svg" alt="Go Reference" />
                         </a>
                     </div>


### PR DESCRIPTION
Fixes the documentation URL in the homepage, as it already includes the protocol:

https://github.com/uber-go/sally/blob/686fb8782cfa89a807ecc6dcbc104c6dab43eb66/handler.go#L45