### PR TITLE
feat: add support for other vcs systems

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,11 @@ type PackageConfig struct {
 	// Defaults to the URL specified in the top-level config.
 	URL string `yaml:"url"`
 
+	// VCS is the version control system of this module.
+	//
+	// Defaults to git.
+	VCS string `yaml:"vcs"`
+
 	// Desc is a plain text description of this module.
 	Desc string `yaml:"description"`
 }
@@ -71,6 +76,15 @@ func Parse(path string) (*Config, error) {
 		host = strings.TrimPrefix(host, "http://")
 		host = strings.TrimSuffix(host, "/")
 		c.Godoc.Host = host
+	}
+
+	// Set default values for the packages.
+	for name, pkg := range c.Packages {
+		if pkg.VCS == "" {
+			pkg.VCS = "git"
+		}
+
+		c.Packages[name] = pkg
 	}
 
 	return &c, err

--- a/config_test.go
+++ b/config_test.go
@@ -16,6 +16,7 @@ packages:
   grpc:
     repo: github.com/grpc/grpc-go
     branch: main
+    vcs: svn
 
 `)
 	defer clean()
@@ -28,8 +29,7 @@ packages:
 
 	pkg, ok := config.Packages["grpc"]
 	assert.True(t, ok)
-
-	assert.Equal(t, pkg, PackageConfig{Repo: "github.com/grpc/grpc-go"})
+	assert.Equal(t, PackageConfig{Repo: "github.com/grpc/grpc-go", VCS: "svn"}, pkg)
 }
 
 func TestParsePackageLevelURL(t *testing.T) {
@@ -83,7 +83,7 @@ packages:
 
 			pkg, ok := config.Packages["grpc"]
 			assert.True(t, ok)
-			assert.Equal(t, PackageConfig{Repo: "github.com/grpc/grpc-go"}, pkg)
+			assert.Equal(t, PackageConfig{Repo: "github.com/grpc/grpc-go", VCS: "git"}, pkg)
 		})
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -49,7 +49,8 @@ func CreateHandler(config *Config) http.Handler {
 			Desc:       pkg.Desc,
 			ModulePath: modulePath,
 			DocURL:     docURL,
-			GitURL:     pkg.Repo,
+			VCS:        pkg.VCS,
+			RepoURL:    pkg.Repo,
 		}
 		pkgs = append(pkgs, pkg)
 
@@ -90,8 +91,11 @@ type sallyPackage struct {
 	// URL at which documentation for the package can be found.
 	DocURL string
 
-	// URL at which the Git repository is hosted.
-	GitURL string
+	// Version control system used by the package.
+	VCS string
+
+	// URL at which the repository is hosted.
+	RepoURL string
 }
 
 type indexHandler struct {
@@ -169,11 +173,13 @@ func (h *packageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := packageTemplate.Execute(w, struct {
 		ModulePath string
-		GitURL     string
+		VCS        string
+		RepoURL    string
 		DocURL     string
 	}{
 		ModulePath: h.Pkg.ModulePath,
-		GitURL:     h.Pkg.GitURL,
+		VCS:        h.Pkg.VCS,
+		RepoURL:    h.Pkg.RepoURL,
 		DocURL:     h.Pkg.DocURL + relPath,
 	})
 	if err != nil {

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,7 @@
                     </div>
                     <div class="five columns">
                         <span class="inline-header">Source:</span>
-                        <a href="//{{ .GitURL }}">{{ .GitURL }}</a>
+                        <a href="//{{ .RepoURL }}">{{ .RepoURL }}</a>
                     </div>
                     <div class="two columns">
                         <a href="//{{ .DocURL }}">

--- a/templates/package.html
+++ b/templates/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="go-import" content="{{ .ModulePath }} git https://{{ .GitURL }}">
+        <meta name="go-import" content="{{ .ModulePath }} {{ .VCS }} https://{{ .RepoURL }}">
         <meta http-equiv="refresh" content="0; url={{ .DocURL }}">
     </head>
     <body>


### PR DESCRIPTION
Adds support to other VCS systems as per the specification. Defaults to `git` for backwards compatibility. Also renamed the internally used `.GitURL` to `.RepoURL` for clarity.