### PR TITLE
CI: Fix golangci-lint installation step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
       name: Install golangci-lint
       with:
         version: latest
-        args: --version  # make lint will run the linter
+        args: --help # make lint will run the linter
 
     - run: make lint
       name: Lint


### PR DESCRIPTION
Following https://github.com/uber-go/zap/pull/1424 and https://github.com/uber-go/fx/pull/1185 as examples.

`--version` is no longer accepted. Use `--help` instead.