### PR TITLE
Support linux/arm64 via multi-arch build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # This action inspects the GitHub event metadata
       # and fills tags and labels (e.g. 'latest')
       # needed for the build step.
@@ -47,5 +50,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
👋 We would love to work with Sally and this would make validating locally on arm base machines and on arm runners possible.

Installs QEMU during the build and push workflow and then adds both amd and arm as targets in the build and push action.

